### PR TITLE
Multipart boundary validation

### DIFF
--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -113,12 +113,17 @@ export class Multipart implements Part {
     }
 
     /**
-     * The boundary bytes used to separate the parts
+     * Get the boundary bytes used to separate the parts
      */
     public get boundary(): Uint8Array {
         return this.#boundary;
     }
 
+    /**
+     * Set the boundary bytes used to separate the parts
+     * @throws {RangeError} If the boundary is invalid. A valid boundary is 1 to 70 characters long,
+     * does not end with space, and may only contain: A-Z a-z 0-9 '()+_,-./:=? and space
+     */
     public set boundary(boundary: Uint8Array | string) {
         this.#boundary = typeof boundary === "string" ? new TextEncoder().encode(boundary) : boundary;
         if (!Multipart.isValidBoundary(this.#boundary))

--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -120,6 +120,8 @@ export class Multipart implements Part {
 
     public set boundary(boundary: Uint8Array | string) {
         this.#boundary = typeof boundary === "string" ? new TextEncoder().encode(boundary) : boundary;
+        if (!Multipart.isValidBoundary(this.#boundary))
+            throw new RangeError("Boundary must be 1 to 70 characters long, not end with space, and may only contain: A-Z a-z 0-9 '()+_,-./:=? and space");
         this.setHeaders();
     }
 

--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -65,7 +65,7 @@ export class Multipart implements Part {
     public constructor(public readonly parts: Part[], boundary: Uint8Array | string = crypto.randomUUID(), mediaType: string = "multipart/mixed") {
         this.#boundary = typeof boundary === "string" ? new TextEncoder().encode(boundary) : boundary;
         if (!Multipart.isValidBoundary(this.#boundary))
-            throw new RangeError("Boundary must be 1 to 70 characters long, not end with space, and may only contain: A-Z a-z 0-9 '()+_,-./:=? and space");
+            throw new RangeError("Invalid boundary: must be 1 to 70 characters long, not end with space, and may only contain: A-Z a-z 0-9 '()+_,-./:=? and space");
         this.#mediaType = mediaType;
         this.setHeaders();
     }
@@ -121,7 +121,7 @@ export class Multipart implements Part {
     public set boundary(boundary: Uint8Array | string) {
         this.#boundary = typeof boundary === "string" ? new TextEncoder().encode(boundary) : boundary;
         if (!Multipart.isValidBoundary(this.#boundary))
-            throw new RangeError("Boundary must be 1 to 70 characters long, not end with space, and may only contain: A-Z a-z 0-9 '()+_,-./:=? and space");
+            throw new RangeError("Invalid boundary: must be 1 to 70 characters long, not end with space, and may only contain: A-Z a-z 0-9 '()+_,-./:=? and space");
         this.setHeaders();
     }
 

--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -60,7 +60,8 @@ export class Multipart implements Part {
      * @param [boundary] The multipart boundary used to separate the parts. Randomly generated if not provided
      * @param [mediaType] The media type of the multipart. Defaults to "multipart/mixed"
      *
-     * @throws {RangeError} If the boundary is invalid. A valid boundary is 1 to 70 characters long, does not end with space, and may only contain: A-Z a-z 0-9 '()+_,-./:=? and space
+     * @throws {RangeError} If the boundary is invalid. A valid boundary is 1 to 70 characters long,
+     * does not end with space, and may only contain: A-Z a-z 0-9 '()+_,-./:=? and space
      */
     public constructor(public readonly parts: Part[], boundary: Uint8Array | string = crypto.randomUUID(), mediaType: string = "multipart/mixed") {
         this.#boundary = typeof boundary === "string" ? new TextEncoder().encode(boundary) : boundary;

--- a/test/Multipart.test.js
+++ b/test/Multipart.test.js
@@ -27,30 +27,6 @@ describe("Multipart", function () {
             expect(new TextDecoder().decode(multipart.boundary)).to.equal("empty-boundary");
             expect(multipart.mediaType).to.equal("multipart/mixed");
         });
-
-        it("should accept only valid boundaries", function () {
-            expect(() => new Multipart([], "")).to.throw(RangeError, "Invalid boundary");
-            expect(() => new Multipart([], " ")).to.throw(RangeError, "Invalid boundary");
-            expect(() => new Multipart([], "a ")).to.throw(RangeError, "Invalid boundary");
-            expect(() => new Multipart([], "0123456789".repeat(7) + "0")).to.throw(RangeError, "Invalid boundary");
-            expect(() => new Multipart([], "foo!bar")).to.throw(RangeError, "Invalid boundary");
-
-            expect(() => new Multipart([], "a")).to.not.throw();
-            expect(() => new Multipart([], "0123456789".repeat(7))).to.not.throw();
-            expect(() => new Multipart([], "foo bar")).to.not.throw();
-            expect(() => new Multipart([], "foo'bar")).to.not.throw();
-            expect(() => new Multipart([], "foo(bar")).to.not.throw();
-            expect(() => new Multipart([], "foo)bar")).to.not.throw();
-            expect(() => new Multipart([], "foo+bar")).to.not.throw();
-            expect(() => new Multipart([], "foo_bar")).to.not.throw();
-            expect(() => new Multipart([], "foo,bar")).to.not.throw();
-            expect(() => new Multipart([], "foo-bar")).to.not.throw();
-            expect(() => new Multipart([], "foo.bar")).to.not.throw();
-            expect(() => new Multipart([], "foo/bar")).to.not.throw();
-            expect(() => new Multipart([], "foo:bar")).to.not.throw();
-            expect(() => new Multipart([], "foo=bar")).to.not.throw();
-            expect(() => new Multipart([], "foo?bar")).to.not.throw();
-        });
     });
 
     describe("parse", function () {
@@ -275,6 +251,30 @@ describe("Multipart", function () {
             ]);
 
             expect(new TextDecoder().decode(bytes)).to.equal(new TextDecoder().decode(expectedBytes));
+        });
+
+        it("should accept only valid boundaries", function () {
+            expect(() => new Multipart([], "").bytes()).to.throw(RangeError, "Invalid boundary");
+            expect(() => new Multipart([], " ").bytes()).to.throw(RangeError, "Invalid boundary");
+            expect(() => new Multipart([], "a ").bytes()).to.throw(RangeError, "Invalid boundary");
+            expect(() => new Multipart([], "0123456789".repeat(7) + "0").bytes()).to.throw(RangeError, "Invalid boundary");
+            expect(() => new Multipart([], "foo!bar").bytes()).to.throw(RangeError, "Invalid boundary");
+
+            expect(() => new Multipart([], "a").bytes()).to.not.throw();
+            expect(() => new Multipart([], "0123456789".repeat(7)).bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo'bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo(bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo)bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo+bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo_bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo,bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo-bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo.bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo/bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo:bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo=bar").bytes()).to.not.throw();
+            expect(() => new Multipart([], "foo?bar").bytes()).to.not.throw();
         });
     });
 });

--- a/test/Multipart.test.js
+++ b/test/Multipart.test.js
@@ -27,6 +27,30 @@ describe("Multipart", function () {
             expect(new TextDecoder().decode(multipart.boundary)).to.equal("empty-boundary");
             expect(multipart.mediaType).to.equal("multipart/mixed");
         });
+
+        it("should accept only valid boundaries", function () {
+            expect(() => new Multipart([], "")).to.throw(RangeError, "Invalid boundary");
+            expect(() => new Multipart([], " ")).to.throw(RangeError, "Invalid boundary");
+            expect(() => new Multipart([], "a ")).to.throw(RangeError, "Invalid boundary");
+            expect(() => new Multipart([], "0123456789".repeat(7) + "0")).to.throw(RangeError, "Invalid boundary");
+            expect(() => new Multipart([], "foo!bar")).to.throw(RangeError, "Invalid boundary");
+
+            expect(() => new Multipart([], "a")).to.not.throw();
+            expect(() => new Multipart([], "0123456789".repeat(7))).to.not.throw();
+            expect(() => new Multipart([], "foo bar")).to.not.throw();
+            expect(() => new Multipart([], "foo'bar")).to.not.throw();
+            expect(() => new Multipart([], "foo(bar")).to.not.throw();
+            expect(() => new Multipart([], "foo)bar")).to.not.throw();
+            expect(() => new Multipart([], "foo+bar")).to.not.throw();
+            expect(() => new Multipart([], "foo_bar")).to.not.throw();
+            expect(() => new Multipart([], "foo,bar")).to.not.throw();
+            expect(() => new Multipart([], "foo-bar")).to.not.throw();
+            expect(() => new Multipart([], "foo.bar")).to.not.throw();
+            expect(() => new Multipart([], "foo/bar")).to.not.throw();
+            expect(() => new Multipart([], "foo:bar")).to.not.throw();
+            expect(() => new Multipart([], "foo=bar")).to.not.throw();
+            expect(() => new Multipart([], "foo?bar")).to.not.throw();
+        });
     });
 
     describe("parse", function () {


### PR DESCRIPTION
This PR adds validation for the Multipart boundary input. As per [RFC 2046, Section 5.1.1.](https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1):

> The only mandatory global parameter for the "multipart" media type is
   the boundary parameter, which consists of 1 to 70 characters from a
   set of characters known to be very robust through mail gateways, and
   NOT ending with white space. (If a boundary delimiter line appears to
   end with white space, the white space must be presumed to have been
   added by a gateway, and must be deleted.)  It is formally specified
   by the following BNF:
> ```bnf
> boundary := 0*69<bchars> bcharsnospace
>
> bchars := bcharsnospace / " "
>
> bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" /
>                  "+" / "_" / "," / "-" / "." /
>                  "/" / ":" / "=" / "?"
> ```

A warning will be shown when parsing multipart with an invalid boundary. An error will be thrown when building a multipart bode bytes.