### PR TITLE
Parse trailing LWSP after multipart boundary delimiter

### DIFF
--- a/src/Component.ts
+++ b/src/Component.ts
@@ -22,7 +22,7 @@ export class Component implements Part {
      * @param data Component byte representation to parse
      */
     public static parse(data: Uint8Array): Component {
-        const hasHeaders = Multipart.findSequenceIndex(data, Multipart.CRLF) !== 0;
+        const hasHeaders = !(data[0] === Multipart.CR && data[1] === Multipart.LF);
         const headersEndIndex = hasHeaders ? Multipart.findSequenceIndex(data, Multipart.combineArrays([Multipart.CRLF, Multipart.CRLF])) + 2 : 0;
 
         const headersBuffer = data.slice(0, headersEndIndex);

--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -272,29 +272,28 @@ export class Multipart implements Part {
      * @param data Multipart body bytes
      * @param boundary The multipart boundary bytes
      * @param [start] The index to start the search at (i.e. the number of bytes to skip/ignore at the beginning of the byte array). Defaults to 0.
+     * @returns The start and end index of the boundary delimiter, or `null` if no boundary delimiter can be found
      * @internal
      */
     private static findBoundaryBounds(data: Uint8Array, boundary: Uint8Array, start = 0): [number, number] | null {
         if (start >= data.length) return null;
         const boundaryStartIndex = Multipart.findSequenceIndex(data, Multipart.combineArrays([Multipart.CRLF, Multipart.DOUBLE_DASH, boundary]), start);
         if (boundaryStartIndex === -1) return null;
-        // ignore any linear whitespace
         let currentEndOfBoundaryIndex = boundaryStartIndex + boundary.length + 4;
         while (currentEndOfBoundaryIndex < data.length) {
             const byte = data[currentEndOfBoundaryIndex];
-            if (byte === Multipart.CR) break;
-            if (byte === Multipart.LF) return null;
+            if (byte === Multipart.CR && data[currentEndOfBoundaryIndex + 1] === Multipart.LF)
+                return [boundaryStartIndex, currentEndOfBoundaryIndex + 2];
             if (byte === Multipart.SP || byte === 0x09) {
                 currentEndOfBoundaryIndex++;
                 continue;
             }
-            // encountered non-linear whitespace after boundary and before any CR or LF
+            // encountered non-linear whitespace after boundary and before any CRLF
             // meaning the boundary could not be terminated, therefore continue search for boundary
             return Multipart.findBoundaryBounds(data, boundary, boundaryStartIndex + 2);
         }
-        if (data[currentEndOfBoundaryIndex + 1] !== Multipart.LF) return null;
 
-        return [boundaryStartIndex, currentEndOfBoundaryIndex + 2];
+        return null;
     }
 
     /**

--- a/test/Multipart.test.js
+++ b/test/Multipart.test.js
@@ -143,7 +143,7 @@ describe("Multipart", function () {
                 'X-Foo: Foo\r\n' +
                 '\r\n' +
                 'The boundary delimiter of this part has trailing SP and tab.\r\n' +
-                '--simple boundary--\r\r\n'
+                '--simple boundary--\t \t\r\n'
 
             const parsedMultipart = Multipart.parseBody(new TextEncoder().encode(string), new TextEncoder().encode("simple boundary"));
 

--- a/test/Multipart.test.js
+++ b/test/Multipart.test.js
@@ -159,6 +159,33 @@ describe("Multipart", function () {
             expect(part3.headers.get("x-foo")).to.equal("Foo");
             expect(new TextDecoder().decode(part3.body)).to.equal("The boundary delimiter of this part has trailing SP and tab.");
         });
+
+        it("should handle strings that look like part boundary", function () {
+            const string =
+                '--simple boundary\r\n' +
+                'X-Foo: Bar\r\n' +
+                '\r\n' +
+                'Can this handle\r\n' +
+                '--simple boundary this is fake\r\n' +
+                '\r\n' +
+                'not new part\r\n' +
+                '--simple boundary\r\n' +
+                'X-Foo: Baz\r\n' +
+                '\r\n' +
+                'Final part\r\n' +
+                '--simple boundary--\r\n'
+
+            const parsedMultipart = Multipart.parseBody(new TextEncoder().encode(string), new TextEncoder().encode("simple boundary"));
+
+            expect(parsedMultipart).to.be.an.instanceof(Multipart);
+            expect(parsedMultipart.parts.length).to.equal(2);
+            const part1 = parsedMultipart.parts[0];
+            expect(part1.headers.get("x-foo")).to.equal("Bar");
+            expect(new TextDecoder().decode(part1.body)).to.equal("Can this handle\r\n--simple boundary this is fake\r\n\r\nnot new part");
+            const part2 = parsedMultipart.parts[1];
+            expect(part2.headers.get("x-foo")).to.equal("Baz");
+            expect(new TextDecoder().decode(part2.body)).to.equal("Final part");
+        });
     });
 
     describe("formData", function () {

--- a/test/Multipart.test.js
+++ b/test/Multipart.test.js
@@ -135,7 +135,10 @@ describe("Multipart", function () {
             const parsedMultipart = Multipart.parse(multipartBytes);
             expect(parsedMultipart).to.be.an.instanceof(Multipart);
             expect(parsedMultipart.parts.length).to.equal(1);
-            expect(new TextDecoder().decode(parsedMultipart.parts[0].bytes())).to.equal("\r\n");
+            const part = parsedMultipart.parts[0];
+            expect(part.bytes()).to.deep.equal(Multipart.CRLF);
+            expect(part.headers).to.be.empty;
+            expect(part.body).to.be.empty;
         });
 
         it("should handle parsing of empty parts in multipart MIME string", function () {
@@ -149,7 +152,10 @@ describe("Multipart", function () {
             const parsedMultipart = Multipart.parse(multipartBytes);
             expect(parsedMultipart).to.be.an.instanceof(Multipart);
             expect(parsedMultipart.parts.length).to.equal(1);
-            expect(new TextDecoder().decode(parsedMultipart.parts[0].bytes())).to.equal("\r\n");
+            const part = parsedMultipart.parts[0];
+            expect(part.bytes()).to.deep.equal(Multipart.CRLF);
+            expect(part.headers).to.be.empty;
+            expect(part.body).to.be.empty;
         });
 
         it("should ignore linear whitespace after boundary delimiter", function () {

--- a/test/Multipart.test.js
+++ b/test/Multipart.test.js
@@ -129,6 +129,29 @@ describe("Multipart", function () {
             expect(parsedMultipart.parts).to.be.empty;
         });
 
+        it("should parse Multipart from empty Component bytes", function () {
+            const multipart = new Multipart([new Component({})]);
+            const multipartBytes = multipart.bytes();
+            const parsedMultipart = Multipart.parse(multipartBytes);
+            expect(parsedMultipart).to.be.an.instanceof(Multipart);
+            expect(parsedMultipart.parts.length).to.equal(1);
+            expect(new TextDecoder().decode(parsedMultipart.parts[0].bytes())).to.equal("\r\n");
+        });
+
+        it("should handle parsing of empty parts in multipart MIME string", function () {
+            const string = "Content-type: multipart/mixed; boundary=\"simple boundary\"\r\n\r\n"
+                + "--simple boundary\r\n"
+                + "\r\n"
+                + "\r\n"
+                + "--simple boundary--\r\n";
+            const multipart = Multipart.parse(new TextEncoder().encode(string));
+            const multipartBytes = multipart.bytes();
+            const parsedMultipart = Multipart.parse(multipartBytes);
+            expect(parsedMultipart).to.be.an.instanceof(Multipart);
+            expect(parsedMultipart.parts.length).to.equal(1);
+            expect(new TextDecoder().decode(parsedMultipart.parts[0].bytes())).to.equal("\r\n");
+        });
+
         it("should ignore linear whitespace after boundary delimiter", function () {
             const string =
                 '--simple boundary    \r\n' +


### PR DESCRIPTION
As per RFC 2046, any linear whitespace after the boundary delimiter should be ignored.