### PR TITLE
Make the `boundary` param in Multipart `Conten-Type` quoted as needed per RFC 2616

### DIFF
--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -444,15 +444,15 @@ export class Multipart implements Part {
             if (
                 byte === Multipart.HT
                 || byte === Multipart.SP
-                || byte === 0x22
-                || byte === 0x28
-                || byte === 0x29
-                || byte === 0x2c
-                || byte === 0x2f
-                || (byte >= Multipart.COLON && byte <= 0x40)
-                || (byte >= 0x5b && byte <= 0x5d)
-                || byte === 0x7b
-                || byte === 0x7d
+                || byte === 0x22 // "
+                || byte === 0x28 // (
+                || byte === 0x29 // )
+                || byte === 0x2c // ,
+                || byte === 0x2f // /
+                || (byte >= Multipart.COLON && byte <= 0x40) // :;<=>@
+                || (byte >= 0x5b && byte <= 0x5d) // [\]
+                || byte === 0x7b // {
+                || byte === 0x7d // }
             ) return true;
         }
         return false;

--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -25,6 +25,11 @@ export class Multipart implements Part {
      */
     public static readonly SP = 0x20;
     /**
+     * Horizontal tab (`\t`) ASCII code
+     * @internal
+     */
+    public static readonly HT = 0x09;
+    /**
      * Carriage return (`\r`) ASCII code
      * @internal
      */
@@ -284,7 +289,7 @@ export class Multipart implements Part {
             const byte = data[currentEndOfBoundaryIndex];
             if (byte === Multipart.CR && data[currentEndOfBoundaryIndex + 1] === Multipart.LF)
                 return [boundaryStartIndex, currentEndOfBoundaryIndex + 2];
-            if (byte === Multipart.SP || byte === 0x09) {
+            if (byte === Multipart.SP || byte === Multipart.HT) {
                 currentEndOfBoundaryIndex++;
                 continue;
             }

--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -439,10 +439,32 @@ export class Multipart implements Part {
         return Multipart.combineArrays(result);
     }
 
+    private static boundaryShouldBeQuoted(boundary: Uint8Array): boolean {
+        for (const byte of boundary) {
+            if (
+                byte === Multipart.HT
+                || byte === Multipart.SP
+                || byte === 0x22
+                || byte === 0x28
+                || byte === 0x29
+                || byte === 0x2c
+                || byte === 0x2f
+                || (byte >= Multipart.COLON && byte <= 0x40)
+                || (byte >= 0x5b && byte <= 0x5d)
+                || byte === 0x7b
+                || byte === 0x7d
+            ) return true;
+        }
+        return false;
+    }
+
     /**
      * Set the `Content-Type` header of this multipart based on {@link mediaType} and {@link boundary}.
      */
     private setHeaders() {
-        this.headers.set("Content-Type", this.#mediaType + "; boundary=" + new TextDecoder().decode(this.#boundary));
+        const shouldQuoteBoundary = Multipart.boundaryShouldBeQuoted(this.#boundary);
+        const boundaryString = new TextDecoder().decode(this.#boundary);
+        const boundary = shouldQuoteBoundary ? `"${boundaryString.replace(/"/g, '\\"')}"` : boundaryString;
+        this.headers.set("Content-Type", this.#mediaType + "; boundary=" + boundary);
     }
 }

--- a/test/Multipart.test.js
+++ b/test/Multipart.test.js
@@ -364,4 +364,28 @@ describe("Multipart", function () {
             expect(() => new Multipart([], "foo?bar").bytes()).to.not.throw();
         });
     });
+
+    describe("#headers", function () {
+        it("should have the Content-Type boundary parameters in quotes as per RFC 2616", function () {
+            expect(new Multipart([], "foobar", "multipart/mixed").headers.get("content-type")).to.equal("multipart/mixed; boundary=foobar");
+            expect(new Multipart([], "foo\tbar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo\tbar"');
+            expect(new Multipart([], "foo bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo bar"');
+            expect(new Multipart([], 'foo"bar', "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo\\"bar"');
+            expect(new Multipart([], "foo(bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo(bar"');
+            expect(new Multipart([], "foo)bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo)bar"');
+            expect(new Multipart([], "foo,bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo,bar"');
+            expect(new Multipart([], "foo:bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo:bar"');
+            expect(new Multipart([], "foo;bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo;bar"');
+            expect(new Multipart([], "foo<bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo<bar"');
+            expect(new Multipart([], "foo=bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo=bar"');
+            expect(new Multipart([], "foo>bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo>bar"');
+            expect(new Multipart([], "foo?bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo?bar"');
+            expect(new Multipart([], "foo@bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo@bar"');
+            expect(new Multipart([], "foo[bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo[bar"');
+            expect(new Multipart([], "foo\\bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo\\bar"');
+            expect(new Multipart([], "foo]bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo]bar"');
+            expect(new Multipart([], "foo{bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo{bar"');
+            expect(new Multipart([], "foo}bar", "multipart/mixed").headers.get("content-type")).to.equal('multipart/mixed; boundary="foo}bar"');
+        });
+    });
 });


### PR DESCRIPTION
Example:
```
Content-Type: multipart/mixed; boundary=foobar
Content-Type: multipart/mixed; boundary="foo bar"
```