### PR TITLE
Add support for `Blob`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,14 @@ http.createServer(async (req, res) => {
     if (req.method === "POST" && req.headers["content-type"]) {
 
         // get the request body
-        const chunks: Uint8Array[] = [];
+        const body: Uint8Array[] = [];
         for await (const chunk of req)
-            chunks.push(chunk);
-        const body = Buffer.concat(chunks);
+            body.push(chunk);
 
-        // create a multipart component to hold the content-type header (which includes the boundary) and the body
-        const component = new Component({
-                "Content-Type": req.headers["content-type"]
-            }, body);
-        // parse multipart from the component
-        const multipart = Multipart.part(component);
+        // create a blob to hold the Content-Type header (which includes the boundary) and the body
+        const blob = new Blob(body, {type: req.headers["content-type"]});
+        // parse multipart from the blob
+        const multipart = await Multipart.blob(blob);
         console.log(multipart);
 
         res.end("ok");

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -54,6 +54,18 @@ export class Component implements Part {
         return new Component(file.type.length > 0 ? {"Content-Type": file.type} : {}, await file.arrayBuffer());
     }
 
+    /**
+     * Create a Component from a {@link !Blob}. If blob media type is available,
+     * it will be set in the `Content-Type` header. The blob's contents will be used as the part's body.
+     *
+     * This method might be slow if a large file is provided as the blob contents need to be read.
+     *
+     * @param blob Blob to create the component from
+     */
+    public static async blob(blob: Blob) {
+        return new Component(blob.type.length > 0 ? {"Content-Type": blob.type} : {}, await blob.arrayBuffer());
+    }
+
     public bytes(): Uint8Array {
         const result: ArrayLike<number>[] = [];
         for (const [key, value] of this.headers.entries())

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -43,15 +43,16 @@ export class Component implements Part {
     }
 
     /**
-     * Create a Component from a {@link File}. If file media type is available,
+     * Create a Component from a {@link !File}. If file media type is available,
      * it will be set in the `Content-Type` header. The file's contents will be used as the part's body.
      *
      * This method might be slow if a large file is provided as the file contents need to be read.
      *
      * @param file File instance to create the component from
+     * @deprecated Use {@link Component.blob}.
      */
     public static async file(file: File) {
-        return new Component(file.type.length > 0 ? {"Content-Type": file.type} : {}, await file.arrayBuffer());
+        return await Component.blob(file);
     }
 
     /**

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -79,4 +79,11 @@ export class Component implements Part {
         result.push(this.body);
         return Multipart.combineArrays(result);
     }
+
+    /**
+     * A Blob representation of this component. Headers will be lost.
+     */
+    public blob(): Blob {
+        return new Blob([this.body], {type: this.headers.get("Content-Type") ?? undefined});
+    }
 }

--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -244,7 +244,7 @@ export class Multipart implements Part {
         for (const [key, value] of formData.entries()) {
             if (typeof value === "string") parts.push(new Component({"Content-Disposition": `form-data; name="${key}"`}, new TextEncoder().encode(value)));
             else {
-                const part = await Component.file(value);
+                const part = await Component.blob(value);
                 part.headers.set("Content-Disposition", `form-data; name="${key}"; filename="${value.name}"`);
                 parts.push(part);
             }

--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -232,6 +232,19 @@ export class Multipart implements Part {
     }
 
     /**
+     * Create Multipart from a {@link !Blob}. The boundary and media type are determined from the blob's type.
+     * @param blob The blob
+     * @throws {@link !SyntaxError} If the `Content-Type` header is missing or does not include a boundary
+     */
+    public static async blob(blob: Blob): Promise<Multipart> {
+        const type = blob.type;
+        if (type === "") throw new SyntaxError("Blob is missing Content-Type header");
+        const {mediaType, boundary} = Multipart.parseContentType(type);
+        if (boundary === null) throw new SyntaxError("Missing boundary in Content-Type header of blob");
+        return Multipart.parseBody(new Uint8Array(await blob.arrayBuffer()), new TextEncoder().encode(boundary), mediaType ?? void 0);
+    }
+
+    /**
      * Create Multipart from {@link FormData}.
      * This method might be slow if the form data contains large files.
      *

--- a/src/Multipart.ts
+++ b/src/Multipart.ts
@@ -439,6 +439,16 @@ export class Multipart implements Part {
         return Multipart.combineArrays(result);
     }
 
+    /**
+     * Create Blob from this multipart.
+     *
+     * @throws {@link !RangeError} If the multipart boundary is invalid. A valid boundary is 1 to 70 characters long,
+     * does not end with space, and may only contain: A-Z a-z 0-9 '()+_,-./:=? and space.
+     */
+    public blob(): Blob {
+        return new Blob([this.bytes()], {type: this.headers.get("content-type") ?? undefined});
+    }
+
     private static boundaryShouldBeQuoted(boundary: Uint8Array): boolean {
         for (const byte of boundary) {
             if (

--- a/test/Component.test.js
+++ b/test/Component.test.js
@@ -79,6 +79,22 @@ describe("Component", () => {
         });
     });
 
+    describe("blob", () => {
+        it("should create Component from Blob with type", async () => {
+            const blob = new Blob([new Uint8Array([1, 2, 3])], {type: "text/plain"});
+            const component = await Component.blob(blob);
+            expect(component.headers.get("Content-Type")).to.equal("text/plain");
+            expect(component.body).to.deep.equal(new Uint8Array([1, 2, 3]));
+        });
+
+        it ("should create Component from Blob without type", async () => {
+            const blob = new Blob([new Uint8Array([1, 2, 3])]);
+            const component = await Component.blob(blob);
+            expect(component.headers.get("Content-Type")).to.equal(null);
+            expect(component.body).to.deep.equal(new Uint8Array([1, 2, 3]));
+        });
+    });
+
     describe("#bytes", () => {
         it("should return the bytes of a Component with headers and body", () => {
             const headersInit = {"Content-Type": "text/plain", "Content-Length": "3"};
@@ -95,6 +111,25 @@ describe("Component", () => {
             const bytes = component.bytes();
             const expected = 'content-length: 3\r\ncontent-type: text/plain\r\n\r\n';
             expect(new TextDecoder().decode(bytes)).to.equal(expected);
+        });
+    });
+
+    describe("#blob", () => {
+        it("should return the Blob of a Component with headers and body", async () => {
+            const headersInit = {"Content-Type": "text/plain", "Content-Length": "3"};
+            const body = new Uint8Array([1, 2, 3]);
+            const component = new Component(headersInit, body);
+            const blob = component.blob();
+            expect(blob.type).to.equal("text/plain");
+            expect(await blob.bytes()).to.deep.equal(body);
+        });
+
+        it("should return the Blob of a Component with only headers", async () => {
+            const headersInit = {"Content-Type": "text/plain", "Content-Length": "3"};
+            const component = new Component(headersInit);
+            const blob = component.blob();
+            expect(blob.type).to.equal("text/plain");
+            expect(await blob.bytes()).to.deep.equal(new Uint8Array(0));
         });
     });
 });

--- a/test/Component.test.js
+++ b/test/Component.test.js
@@ -1,5 +1,6 @@
 import {expect} from "chai";
 import {Multipart, Component} from "../dist/index.js";
+import {describe} from "mocha";
 
 describe("Component", () => {
 


### PR DESCRIPTION
Multiparts and components can now be created from and represented as a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob).

Deprecated `Component.file` in favour of `Component.blob` (File extends Blob).