### PR TITLE
Removed Dependabot reviewers setting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
       interval: weekly
       day: monday
       time: "06:00"
-    reviewers:
-      - zefir-git
 
   - package-ecosystem: github-actions
     directory: /
@@ -15,5 +13,3 @@ updates:
       interval: weekly
       day: monday
       time: "06:00"
-    reviewers:
-      - zefir-git


### PR DESCRIPTION
`reviewers` is deprecated in favour of the CODEOWNERS file